### PR TITLE
Fix: Lowercase column names in demographic pivot models for Snowflake persist_docs compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# dbt_youtube_analytics v1.0.1
+
+## Bug Fixes
+- Fixed mixed-case column names in `youtube__age_demographics_pivot` and `youtube__gender_demographics_pivot` models that were causing issues with Snowflake's `persist_docs` functionality. Column names are now consistently lowercase (e.g., `age_25_34_view_percentage` instead of `AGE_25_34_view_percentage`).
+- Updated corresponding documentation in `models/youtube.yml` to reflect the lowercase column names.
+
+## Under the Hood
+- Applied `| lower` filter to dynamically generated column names in pivot models to ensure consistent casing across different database platforms.
+
 # dbt_youtube_analytics v1.0.0
 
 [PR #23](https://github.com/fivetran/dbt_youtube_analytics/pull/23) includes the following updates:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'youtube_analytics'
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'youtube_analytics_integration_tests'
-version: '1.0.0'
+version: '1.0.1'
 profile: 'integration_tests'
 config-version: 2
 vars:

--- a/models/youtube.yml
+++ b/models/youtube.yml
@@ -70,19 +70,19 @@ models:
         description: The channel title
       - name: default_thumbnail_url
         description: The default thumbnail url
-      - name: AGE_25_34_view_percentage
+      - name: age_25_34_view_percentage
         description: Total number of views percent attributed to the age range 25 - 34 years old
-      - name: AGE_35_44_view_percentage
+      - name: age_35_44_view_percentage
         description: Total number of views percent attributed to the age range 35 - 44 years old
-      - name: AGE_45_54_view_percentage
+      - name: age_45_54_view_percentage
         description: Total number of views percent attributed to the age range 45 - 54 years old
-      - name: AGE_18_24_view_percentage
+      - name: age_18_24_view_percentage
         description: Total number of views percent attributed to the age range 18 - 24 years old
-      - name: AGE_65__view_percentage
+      - name: age_65__view_percentage
         description: Total number of views percent attributed to the age range 65 years and older
-      - name: AGE_55_64_view_percentage
+      - name: age_55_64_view_percentage
         description: Total number of views percent attributed to the age range 55 - 64 years old
-      - name: AGE_13_17_view_percentage
+      - name: age_13_17_view_percentage
         description: Total number of views percent attributed to the age range 13 - 17 years old
       - name: source_relation
         description: The source of the record, if the unioning functionality is being used.
@@ -136,12 +136,14 @@ models:
         description: The channel title
       - name: default_thumbnail_url
         description: The default thumbnail url
-      - name: MALE_view_percentage
+      - name: male_view_percentage
         description: Total number of views percent attributed to the viewers who identify as male
-      - name: FEMALE_view_percentage
+      - name: female_view_percentage
         description: Total number of views percent attributed to the viewers who identify as female
-      - name: GENDER_OTHER_view_percentage
+      - name: gender_other_view_percentage
         description: Total number of views percent attributed to the viewers who identify as neither male or female
+      - name: user_specified_view_percentage
+        description: Total number of views percent attributed to the viewers who have specified their gender
       - name: source_relation
         description: The source of the record, if the unioning functionality is being used.
 

--- a/models/youtube__age_demographics_pivot.sql
+++ b/models/youtube__age_demographics_pivot.sql
@@ -25,7 +25,7 @@ with age_pivot as (
         video_metadata.default_thumbnail_url
         
         {% for col in age_columns -%}
-            , age_pivot.{% if target.type in ('postgres, redshift') %}"{{ col }}"{% else %}{{ col }}{% endif %} as {{ col }}_view_percentage
+            , age_pivot.{% if target.type in ('postgres, redshift') %}"{{ col }}"{% else %}{{ col }}{% endif %} as {{ col | lower }}_view_percentage
         {% endfor -%}
     from age_pivot
 

--- a/models/youtube__gender_demographics_pivot.sql
+++ b/models/youtube__gender_demographics_pivot.sql
@@ -26,7 +26,7 @@ with gender_pivot as (
         video_metadata.default_thumbnail_url
         
         {% for col in gender_columns -%}
-            , gender_pivot.{% if target.type in ('postgres, redshift') %}"{{ col }}"{% else %}{{ col }}{% endif %} as {{ col }}_view_percentage
+            , gender_pivot.{% if target.type in ('postgres, redshift') %}"{{ col }}"{% else %}{{ col }}{% endif %} as {{ col | lower}}_view_percentage
         {% endfor -%}
     from gender_pivot
 


### PR DESCRIPTION
**Please provide your name and company**
Øyvind Eraker (oeraker@gmail.com) - Independent contributor

**Link the issue/feature request which this PR is meant to address**
This PR addresses an issue with mixed-case column names in the demographic pivot models that cause problems when using Snowflake's `persist_docs` functionality.

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

This PR fixes column name casing inconsistencies in the `youtube__age_demographics_pivot` and `youtube__gender_demographics_pivot` models. 

The issue: 
- Column names were generated with uppercase prefixes (e.g., `AGE_25_34_view_percentage`, `MALE_view_percentage`)
- This caused issues with Snowflake's `persist_docs` feature, which is case-sensitive
- Documentation column names didn't match the actual column names in the models

The solution:
- Added `| lower` filter to the Jinja template that generates column names dynamically
- Updated documentation in `models/youtube.yml` to use lowercase column names
- Bumped package version from 1.0.0 to 1.0.1
- Added CHANGELOG entry documenting the fix

**How did you validate the changes introduced within this PR?**

- Verified that column names are now consistently lowercase in both pivot models
- Confirmed that documentation column names match the actual model column names
- Tested that the `| lower` filter is correctly applied in the Jinja templates
- Ensured version numbers are updated in both main and integration_tests `dbt_project.yml` files

**Which warehouse did you use to develop these changes?**
Snowflake

**Did you update the CHANGELOG?**
- [x] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
- [x] Yes

**Typically there are additional maintenance changes required before this will be ready for an upcoming release. Are you comfortable with the Fivetran team making a few commits directly to your branch?**
- [x] Yes

**If you had to summarize this PR in an emoji, which would it be?**
🔤

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.